### PR TITLE
Fix window storm

### DIFF
--- a/CCTask/CCTask.csproj
+++ b/CCTask/CCTask.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>CCTask</RootNamespace>
     <AssemblyName>CCTask</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/CCTask/CCompilerTask.cs
+++ b/CCTask/CCompilerTask.cs
@@ -29,6 +29,7 @@ using Microsoft.Build.Framework;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using CCTask.Compilers;
+using System.ComponentModel;
 
 namespace CCTask
 {
@@ -65,18 +66,43 @@ namespace CCTask
 			using(var cache = new FileCacheManager(ObjectFilesDirectory))
 			{
 				var objectFiles = new List<string>();
-				var compilationResult = System.Threading.Tasks.Parallel.ForEach(Sources.Select(x => x.ItemSpec), new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = Parallel ? -1 : 1 }, (source, loopState) => {
-					var objectFile = ObjectFilesDirectory == null ? regex.Replace(source, ".o") : string.Format("{0}/{1}", ObjectFilesDirectory, regex.Replace(source, ".o"));
-					if(!compiler.Compile(source, objectFile, flags, cache.SourceHasChanged))
+				System.Threading.Tasks.ParallelLoopResult compilationResult;
+				try
+				{
+					compilationResult = System.Threading.Tasks.Parallel.ForEach(Sources.Select(x => x.ItemSpec), new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = Parallel ? -1 : 1 }, (source, loopState) =>
 					{
-						loopState.Break();
-					}
+						var objectFile = ObjectFilesDirectory == null ? regex.Replace(source, ".o") : string.Format("{0}/{1}", ObjectFilesDirectory, regex.Replace(source, ".o"));
 
-					lock(objectFiles)
+						if (!compiler.Compile(source, objectFile, flags, cache.SourceHasChanged))
+						{
+							loopState.Break();
+						}
+
+						lock (objectFiles)
+						{
+							objectFiles.Add(objectFile);
+						}
+					});
+				}
+				catch(Exception e)
+				{
+					if(e.InnerException is Win32Exception error)
 					{
-						objectFiles.Add(objectFile);
+						if(error.NativeErrorCode == Utilities.ErrorFileNotFound)
+						{
+							Logger.Instance.LogError($"Could not find \"{CompilerPath}\" compiler.");
+						}
+						else
+						{
+							Logger.Instance.LogError($"An error was encountered while trying to run \"{CompilerPath}\" compiler: {e.InnerException.Message}.");
+						}
 					}
-				});
+					else 
+					{
+						Logger.Instance.LogError($"An unknown exception has been thrown in CCompilerTask. Message: { e.InnerException?.Message ?? e.Message }.");
+					}
+					return false;
+				}
 				if(compilationResult.LowestBreakIteration != null)
 				{
 					return false;

--- a/CCTask/CCompilerTask.cs
+++ b/CCTask/CCompilerTask.cs
@@ -69,7 +69,12 @@ namespace CCTask
 				System.Threading.Tasks.ParallelLoopResult compilationResult;
 				try
 				{
-					compilationResult = System.Threading.Tasks.Parallel.ForEach(Sources.Select(x => x.ItemSpec), new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = Parallel ? -1 : 1 }, (source, loopState) =>
+					// We normalize the directory separator in paths to make handling of gcc -MM easier.
+					var sourceFiles = System.IO.Path.DirectorySeparatorChar == '\\'
+						? Sources.Select(x => x.ItemSpec.Replace("\\", "/"))
+						: Sources.Select(x => x.ItemSpec);
+
+					compilationResult = System.Threading.Tasks.Parallel.ForEach(sourceFiles, new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = Parallel ? -1 : 1 }, (source, loopState) =>
 					{
 						var objectFile = ObjectFilesDirectory == null ? regex.Replace(source, ".o") : string.Format("{0}/{1}", ObjectFilesDirectory, regex.Replace(source, ".o"));
 

--- a/CCTask/EnvironmentTask.cs
+++ b/CCTask/EnvironmentTask.cs
@@ -7,11 +7,15 @@ namespace CCTask
 	public class EnvironmentTask : Task
 	{
 		[Output]
-		public int PointerSize { get; private set; }
+		public int OsPointerSize { get; private set; }
+
+		[Output]
+		public int FrameworkPointerSize { get; private set; }
 
 		public override bool Execute()
 		{
-			PointerSize = Environment.Is64BitOperatingSystem ? 64 : 32;
+			FrameworkPointerSize = IntPtr.Size * 8;
+			OsPointerSize = Environment.Is64BitOperatingSystem ? 64 : 32;
 			return true;
 		}
 

--- a/CCTask/RunWrapper.cs
+++ b/CCTask/RunWrapper.cs
@@ -36,6 +36,7 @@ namespace CCTask
 			startInfo.RedirectStandardError = true;
 			startInfo.RedirectStandardInput = true;
 			startInfo.RedirectStandardOutput = true;
+			startInfo.CreateNoWindow = true;
 		}
 
 		internal bool Run()

--- a/CCTask/Utilities.cs
+++ b/CCTask/Utilities.cs
@@ -20,6 +20,7 @@ namespace CCTask
 			output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
 			return process.ExitCode == 0;
 		}
+		public const uint ErrorFileNotFound = 0x2;
 	}
 }
 

--- a/CCTask/Utilities.cs
+++ b/CCTask/Utilities.cs
@@ -14,6 +14,7 @@ namespace CCTask
 			startInfo.RedirectStandardError = true;
 			startInfo.RedirectStandardInput = true;
 			startInfo.RedirectStandardOutput = true;
+			startInfo.CreateNoWindow = true;
 			var process = new Process { StartInfo = startInfo };
 			process.Start();
 			process.WaitForExit();


### PR DESCRIPTION
This patch fixes a storm of windows appearing when building Renode under Visual Studio on Windows.